### PR TITLE
Update home screen text to your next upcoming job

### DIFF
--- a/helprs-worker/src/screens/HomeScreen.tsx
+++ b/helprs-worker/src/screens/HomeScreen.tsx
@@ -182,7 +182,7 @@ export default function HomeScreen() {
         {/* Next Upcoming Job Section */}
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Next Upcoming Job</Text>
+            <Text style={styles.sectionTitle}>Your Next Upcoming Job</Text>
             <TouchableOpacity onPress={loadNextJob}>
               <Text style={styles.seeAllText}>Refresh</Text>
             </TouchableOpacity>


### PR DESCRIPTION
Update mobile app home screen to say "Your Next Upcoming Job" instead of "Next Upcoming Job".

---
<a href="https://cursor.com/background-agent?bcId=bc-4530645f-8f0f-426f-91b3-22d7b9f81cb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4530645f-8f0f-426f-91b3-22d7b9f81cb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

